### PR TITLE
Reduce the amount of data fetch from Slack users.info

### DIFF
--- a/functions/fetchUserProfile.ts
+++ b/functions/fetchUserProfile.ts
@@ -1,19 +1,74 @@
+import type { UserProfile } from './../src/javascript/components/TeamMember'
+
+type SlackUser = {
+  id: string
+  team_id: string
+  name: string
+  deleted: boolean
+  color: string
+  real_name: string
+  tz: string
+  tz_label: string
+  tz_offset: number
+  profile: {
+    title: string
+    phone: string
+    skype: string
+    real_name: string
+    real_name_normalized: string
+    display_name: string
+    display_name_normalized: string
+    fields: null
+    status_text: string
+    status_emoji: string
+    status_expiration: number
+    avatar_hash: string
+    image_original: string
+    is_custom_image: boolean
+    first_name: string
+    last_name: string
+    image_24: string
+    image_32: string
+    image_48: string
+    image_72: string
+    image_192: string
+    image_512: string
+    image_1024: string
+    status_text_canonical: string
+    team: string
+  }
+  is_admin: boolean
+  is_owner: boolean
+  is_primary_owner: boolean
+  is_restricted: boolean
+  is_ultra_restricted: boolean
+  is_bot: boolean
+  is_app_user: boolean
+  updated: number
+}
+
 const fetch = require('node-fetch')
 
 const { SLACK_AUTHORIZATION_TOKEN } = process.env
 
-exports.handler = async (event, context) => {
+exports.handler = async (event, context): Promise<UserProfile> => {
   const slackUserID = event.queryStringParameters.userID
   const API_ENDPOINT = `https://slack.com/api/users.info?token=${SLACK_AUTHORIZATION_TOKEN}&user=${slackUserID}`
 
   return fetch(API_ENDPOINT, { headers: { Accept: 'application/json' } })
     .then((response) => response.json())
-    .then((data) => ({
+    .then((data: { user: SlackUser }) => ({
       headers: {
         'Access-Control-Allow-Origin': '*'
       },
       statusCode: 200,
-      body: JSON.stringify(data.user)
+      body: JSON.stringify({
+        id: data.user.id,
+        realName: data.user.real_name,
+        avatar: data.user.profile.image_192,
+        timeZone: data.user.tz,
+        timeZoneLabel: data.user.tz_label
+      })
     }))
     .catch((error) => ({ statusCode: 422, body: String(error) }))
 }

--- a/src/javascript/App.tsx
+++ b/src/javascript/App.tsx
@@ -87,7 +87,7 @@ const App = (): React.ReactElement<'div'> => {
         <div className='team-member-wrapper'>
           {teamMembers.length > 0 ? (
             uniqBy(teamMembers, 'id')
-              .sort((a, b) => a.name.localeCompare(b.name))
+              .sort((a, b) => a.realName.localeCompare(b.realName))
               .map((userProfile: UserProfile) => (
                 <TeamMember key={userProfile.id} userProfile={userProfile} />
               ))

--- a/src/javascript/components/TeamMember.tsx
+++ b/src/javascript/components/TeamMember.tsx
@@ -11,49 +11,10 @@ import { currentTimeState, is24HourState, onlineTeamMemberIds } from '../atoms'
 
 type UserProfile = {
   id: string
-  team_id: string
-  name: string
-  deleted: boolean
-  color: string
-  real_name: string
-  tz: string
-  tz_label: string
-  tz_offset: number
-  profile: {
-    title: string
-    phone: string
-    skype: string
-    real_name: string
-    real_name_normalized: string
-    display_name: string
-    display_name_normalized: string
-    fields: null
-    status_text: string
-    status_emoji: string
-    status_expiration: number
-    avatar_hash: string
-    image_original: string
-    is_custom_image: boolean
-    first_name: string
-    last_name: string
-    image_24: string
-    image_32: string
-    image_48: string
-    image_72: string
-    image_192: string
-    image_512: string
-    image_1024: string
-    status_text_canonical: string
-    team: string
-  }
-  is_admin: boolean
-  is_owner: boolean
-  is_primary_owner: boolean
-  is_restricted: boolean
-  is_ultra_restricted: boolean
-  is_bot: boolean
-  is_app_user: boolean
-  updated: number
+  realName: string
+  avatar: string
+  timeZone: string
+  timeZoneLabel: string
 }
 
 type Props = {
@@ -67,7 +28,7 @@ const TeamMember = ({ userProfile }: Props): React.ReactElement => {
   const show24HourTime = useRecoilValue(is24HourState)
   const currentTime = useRecoilValue(currentTimeState)
 
-  const countryInformation = getCountryForTimezone(userProfile.tz)
+  const countryInformation = getCountryForTimezone(userProfile.timeZone)
 
   // Fetch the Team Members Slack profile and presence status
   React.useEffect((): void => {
@@ -96,23 +57,23 @@ const TeamMember = ({ userProfile }: Props): React.ReactElement => {
           }`}
         />
         <img
-          alt={userProfile.real_name}
+          alt={userProfile.realName}
           className='team-member__avatar__image'
-          src={userProfile.profile.image_192}
+          src={userProfile.avatar}
         />
       </div>
       <div className='team-member__information'>
         <h2 className='team-member__information__name'>
-          {userProfile.real_name}
+          {userProfile.realName}
         </h2>
         <p className='team-member__information__current-time'>
           {format(
-            utcToZonedTime(currentTime, userProfile.tz),
+            utcToZonedTime(currentTime, userProfile.timeZone),
             show24HourTime ? 'HH:mm' : 'hh:mm a'
           )}
         </p>
         <small className='team-member__information__timezone'>
-          {userProfile.tz}
+          {userProfile.timeZone}
         </small>
         {countryInformation && (
           <img


### PR DESCRIPTION
This commit adjusts the `fetchUserProfile` function to reduce the amount of data
we actually need to access and pass to the front-end. Previously, the function
just returned the raw response of the endpoint without any translation.

Now, we only return the fields we need to access in a more accessible and easy
to work with object.